### PR TITLE
Remove implicit nullable parameters

### DIFF
--- a/includes/class-wc-postfinancecheckout-unique-id.php
+++ b/includes/class-wc-postfinancecheckout-unique-id.php
@@ -80,7 +80,7 @@ class WC_PostFinanceCheckout_Unique_Id {
 	 *
 	 * @return WC_Order_Item_Product $item item
 	 */
-	public static function copy_unqiue_id_to_order_item( WC_Order_Item_Product $item, $cart_item_key, $values, WC_Order $order = null ) { //phpcs:ignore
+	public static function copy_unqiue_id_to_order_item( WC_Order_Item_Product $item, $cart_item_key, $values, ?WC_Order $order = null ) { //phpcs:ignore
 		// We do not use the cart_item_key as it is deprecated.
 		$item->add_meta_data( '_postfinancecheckout_unique_line_item_id', self::get_uuid(), true );
 		return $item;
@@ -96,7 +96,7 @@ class WC_PostFinanceCheckout_Unique_Id {
 	 *
 	 * @return WC_Order_Item_Shipping $item item
 	 */
-	public static function copy_unqiue_id_to_order_shipping( WC_Order_Item_Shipping $item, $package_key, $package, WC_Order $order = null ) { //phpcs:ignore
+	public static function copy_unqiue_id_to_order_shipping( WC_Order_Item_Shipping $item, $package_key, $package, ?WC_Order $order = null ) { //phpcs:ignore
 		$item->add_meta_data( '_postfinancecheckout_unique_line_item_id', self::get_uuid(), true );
 		return $item;
 	}
@@ -111,7 +111,7 @@ class WC_PostFinanceCheckout_Unique_Id {
 	 *
 	 * @return WC_Order_Item_Shipping $item item
 	 */
-	public static function copy_unqiue_id_to_order_fee( WC_Order_Item_Fee $item, $fee_key, $fee, WC_Order $order = null ) { //phpcs:ignore
+	public static function copy_unqiue_id_to_order_fee( WC_Order_Item_Fee $item, $fee_key, $fee, ?WC_Order $order = null ) { //phpcs:ignore
 		$unique_id = null;
 		if ( $fee->amount < 0 ) {
 			$unique_id = 'discount-' . $fee->id;

--- a/includes/packages/coupon/class-wc-postfinancecheckout-packages-coupon-discount.php
+++ b/includes/packages/coupon/class-wc-postfinancecheckout-packages-coupon-discount.php
@@ -97,7 +97,7 @@ class WC_PostFinanceCheckout_Packages_Coupon_Discount {
 	 *
 	 * @return WC_Order_Item_Product $item item
 	 */
-	public static function copy_total_coupon_discount_meta_data_to_order_item( WC_Order_Item_Product $item, $cart_item_key, $values, WC_Order $order = null ) { //phpcs:ignore
+	public static function copy_total_coupon_discount_meta_data_to_order_item( WC_Order_Item_Product $item, $cart_item_key, $values, ?WC_Order $order = null ) { //phpcs:ignore
 		$coupon_discount = apply_filters( 'wc_postfinancecheckout_packages_coupon_percentage_discounts_by_item', $cart_item_key ); //phpcs:ignore
 		$item->add_meta_data( '_postfinancecheckout_coupon_discount_line_item_discounts', $coupon_discount );
 		return $item;

--- a/postfinancecheckout.php
+++ b/postfinancecheckout.php
@@ -1120,7 +1120,7 @@ if ( ! class_exists( 'WooCommerce_PostFinanceCheckout' ) ) {
 		 * @param WC_Order|null $order order.
 		 * @return false|mixed
 		 */
-		public function order_editable_check( $allowed, WC_Order $order = null ) {
+		public function order_editable_check( $allowed, ?WC_Order $order = null ) {
 			if ( is_null( $order ) ) {
 				return $allowed;
 			}
@@ -1137,7 +1137,7 @@ if ( ! class_exists( 'WooCommerce_PostFinanceCheckout' ) ) {
 		 * @param WC_Order|null $order order.
 		 * @return mixed
 		 */
-		public function valid_order_status_for_completion( $statuses, WC_Order $order = null ) { //phpcs:ignore
+		public function valid_order_status_for_completion( $statuses, ?WC_Order $order = null ) { //phpcs:ignore
 			if ( WC_PostFinanceCheckout_Helper::is_custom_status_mapping_enabled() ) {
 				$statuses[] = 'postfi-waiting';
 				$statuses[] = 'postfi-manual';


### PR DESCRIPTION
Having implicit nullable parameters is deprecated in PHP 8.4.

This fix replaces `WC_Order $order = null` by `?WC_Order $order = null` (added `?` to make it explicit).

This removes the deprecated notices.